### PR TITLE
Simplify language system to german fallback

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -16,8 +16,6 @@ class Client {
   };
 
   String username;
-  // TODO(lenny): add unkown language by default and ask players to provide one.
-  String lang = "en";
   int chatId = 0;
   boolean nameChangeHintSent = false;
   Status status = Client.Status.IDLE;

--- a/Main.java
+++ b/Main.java
@@ -308,7 +308,7 @@ public class Main {
         // Nothing found: with 50% chance send wiseman message, otherwise send the generated message
         boolean sendWisdom = Utils.roll(50);
         if (sendWisdom) {
-          Messenger.send(client.chatId, PhraseGenerator.getWisdom(client).get(client.lang));
+          Messenger.send(client.chatId, PhraseGenerator.getWisdom(client));
         } else {
           String notFound = Gemini.AskGemini(GAME_DESCRIPTION_PROMPT + " " + NOT_FOUND_PROMPT);
           if (notFound == "") {
@@ -395,8 +395,7 @@ public class Main {
 
     if (!txt.startsWith("/")) {
       String message = "\uD83D\uDCE2 " + client.username + ": " + txt;
-      int numListeners = sendToActiveUsers(
-          PhraseGenerator.getLangMap(message)) - 1;
+      int numListeners = sendToActiveUsers(message) - 1;
       if (numListeners == 0) {
         Messenger.send(client.chatId, "You were not heard by anyone :(");
       }
@@ -408,14 +407,14 @@ public class Main {
   }
 
   // returns number of people who heard you
-  private static int sendToActiveUsers(Map<String, String> message) {
+  private static int sendToActiveUsers(String message) {
     // If changed - also change the other function with the same name.
     int numListeners = 0;
     List<Integer> passive = new LinkedList<>();
     for (int recepientChatId : activeChats) {
       Client recepient = Storage.getClientByChatId(recepientChatId);
       if (recepient.lastActivity > curTimeSeconds - CHAT_TIMEOUT) {
-        Messenger.send(recepient.chatId, message.get(recepient.lang));
+        Messenger.send(recepient.chatId, message);
         numListeners++;
       } else {
         passive.add(recepientChatId);

--- a/PhraseGenerator.java
+++ b/PhraseGenerator.java
@@ -4,71 +4,41 @@ import java.util.HashMap;
 import java.util.Map;
 
 class PhraseGenerator {
-  static String[] languages = {"en", "ru", "de"};
-
-  static Map<String, String> getJoinedTheFightClub(String username) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang, username + " " +
-        getTranslation(Phrases.miscTexts.joinedTheFightClub, lang));
-    }
-    return result;
+  static String getJoinedTheFightClub(String username) {
+    return username + " " + Phrases.miscTexts.joinedTheFightClub;
   }
 
-  static Map<String, String> getReadyToFightPhrase(Client client) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang, "\u2694 " + client.username + " " +
-        Utils.getRnd(getTranslation(
-            Phrases.combatTexts.lookingForOpponent, lang)) + ".");
-    }
-    return result;
+  static String getReadyToFightPhrase(Client client) {
+    return "\u2694 " + client.username + " " +
+        Utils.getRnd(Phrases.combatTexts.lookingForOpponent) + ".";
   }
 
-  static Map<String, String> getWonPhrase(Client winner, Client loser) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang, "\u2620 " + winner.username + " " +
-        Utils.getRnd(getTranslation(Phrases.combatTexts.won, lang)) + " " +
-        loser.username + ".");
-    }
-    return result;
+  static String getWonPhrase(Client winner, Client loser) {
+    return "\u2620 " + winner.username + " " +
+        Utils.getRnd(Phrases.combatTexts.won) + " " + loser.username + ".";
   }
 
-  static Map<String, String> getWisdom(Client client) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang,
-        Utils.getRnd(getTranslation(Phrases.wiseTexts.wisdomIntro,
-            client.lang)) + " " +
-        Utils.getRnd(getTranslation(Phrases.wiseTexts.wisdoms,
-            client.lang)));
-    }
-    return result;
+  static String getWisdom(Client client) {
+    return Utils.getRnd(Phrases.wiseTexts.wisdomIntro) + " " +
+        Utils.getRnd(Phrases.wiseTexts.wisdoms);
   }
 
-  static Map<String, String> getHitPhrase(Client offender,
+  static String getHitPhrase(Client offender,
                              Client victim,
                              Client.BodyPart part,
                              boolean critHit,
                              int damage) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      // Don't think about StringBuilder, it's a lie.
-      // https://stackoverflow.com/questions/4965513/stringbuilder-vs-string-considering-replace 
-      String tmp = victim.username + " " + Utils.getRnd(getTranslation(
-            Phrases.combatTexts.wasDoingSomething, lang)) + ", " +
-        Utils.getRnd(getTranslation(Phrases.combatTexts.when, lang)) + " " +
-        Utils.getRnd(getTranslation(Phrases.combatTexts.adjective, lang)) +
-        " " + offender.username +  " " + Utils.getRnd(getTranslation(
-            Phrases.combatTexts.hit, lang)[part.ordinal()]) + ". ";
-      if (critHit) {
-        tmp += "Critical hit! ";
-      }
-      tmp += "-" + damage + " [" + victim.hp + "/" + victim.getMaxHp() + "]";
-      result.put(lang, tmp);
+    // Don't think about StringBuilder, it's a lie.
+    // https://stackoverflow.com/questions/4965513/stringbuilder-vs-string-considering-replace 
+    String tmp = victim.username + " " + Utils.getRnd(Phrases.combatTexts.wasDoingSomething) + ", " +
+        Utils.getRnd(Phrases.combatTexts.when) + " " +
+        Utils.getRnd(Phrases.combatTexts.adjective) +
+        " " + offender.username +  " " + Utils.getRnd(Phrases.combatTexts.hit[part.ordinal()]) + ". ";
+    if (critHit) {
+      tmp += "Critical hit! ";
     }
-    return result;
+    tmp += "-" + damage + " [" + victim.hp + "/" + victim.getMaxHp() + "]";
+    return tmp;
   }
 
   static String attackToVictim(Client offender, Client victim, int damage) {
@@ -89,35 +59,5 @@ class PhraseGenerator {
     }
     tmp += "-" + damage + " [" + victim.hp + "/" + victim.getMaxHp() + "]";
     return tmp;
-  }
-
-  static Map<String, String> getSayingPhrase(Client teller, String msg, Client listener) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang, teller.username + " " +
-        Utils.getRnd(getTranslation(Phrases.combatTexts.said, lang)) + " " +
-        listener.username + ": " + msg);
-    }
-    return result;
-  }
-
-  static Map<String, String> getLangMap(String message) {
-    Map<String, String> result = new HashMap<>();
-    for (String lang : languages) {
-      result.put(lang, message);
-    }
-    return result;
-  }
-
-  private static <K> K getTranslation(Map<String, K> translations,
-                                       String targetLang) {
-    if (translations.get(targetLang) == null) {
-      if (translations.get("en") == null) {
-        Logger.logException(new Exception("No language for the phrase:" +
-            translations.toString()));
-      }
-      return translations.get("en");
-    }
-    return translations.get(targetLang);
   }
 };

--- a/Phrases.java
+++ b/Phrases.java
@@ -10,18 +10,12 @@ import java.util.Map;
 class Phrases {
   class CombatTexts {
     String[] adjective;
-    String[] blocked;
-    String[] but;
     String[] lookingForOpponent;
-    String[] missed;
-    String[] said;
     String[] wasDoingSomething;
-    String[] wasTrying;
     String[] when;
     String[] won;
 
     String[][] hit;
-    String[][] toHit;
   }
 
   class WiseTexts {

--- a/Phrases.java
+++ b/Phrases.java
@@ -9,31 +9,29 @@ import java.util.Map;
 
 class Phrases {
   class CombatTexts {
-    Map<String, String[]> adjective;
-    Map<String, String[]> blocked;
-    Map<String, String[]> but;
-    Map<String, String[]> lookingForOpponent;
-    Map<String, String[]> missed;
-    Map<String, String[]> said;
-    Map<String, String[]> wasDoingSomething;
-    Map<String, String[]> wasTrying;
-    Map<String, String[]> when;
-    Map<String, String[]> wisdomIntro;
-    Map<String, String[]> wisdoms;
-    Map<String, String[]> won;
+    String[] adjective;
+    String[] blocked;
+    String[] but;
+    String[] lookingForOpponent;
+    String[] missed;
+    String[] said;
+    String[] wasDoingSomething;
+    String[] wasTrying;
+    String[] when;
+    String[] won;
 
-    Map<String, String[][]> hit;
-    Map<String, String[][]> toHit;
+    String[][] hit;
+    String[][] toHit;
   }
 
   class WiseTexts {
-    Map<String, String[]> wisdomIntro;
-    Map<String, String[]> wisdoms;
+    String[] wisdomIntro;
+    String[] wisdoms;
   }
 
 
   class Misc {
-    Map<String, String> joinedTheFightClub;
+    String joinedTheFightClub;
   }
 
   static WiseTexts wiseTexts;

--- a/text/combats.json
+++ b/text/combats.json
@@ -1,383 +1,180 @@
 {
-  "adjective": {
-    "en": [
-      "furious",
-      "dangerous",
-      "rabid",
-      "mad",
-      "wild",
-      "frenzied",
-      "impudent",
-      "insolent",
-      "shameless",
-      "bold",
-      "insidious",
-      "treacherous",
-      "cunning",
-      "sly",
-      "crafty",
-      "naughty",
-      "wicked",
-      "rude",
-      "nasty",
-      "timid",
-      "shy"
+  "adjective": [
+    "furious",
+    "dangerous",
+    "rabid",
+    "mad",
+    "wild",
+    "frenzied",
+    "impudent",
+    "insolent",
+    "shameless",
+    "bold",
+    "insidious",
+    "treacherous",
+    "cunning",
+    "sly",
+    "crafty",
+    "naughty",
+    "wicked",
+    "rude",
+    "nasty",
+    "timid",
+    "shy"
+  ],
+  "blocked": [
+    "skillfully blocked the hit",
+    "masterfully avoided the blow",
+    "stepped back to avoid the hit",
+    "quickly dodged",
+    "rapidly darted away",
+    "cautiously rushed away",
+    "anticipated it and was able to get away with no damage",
+    "forsaw it and managed to end up without a scratch"
+  ],
+  "but": [
+    "but",
+    "when",
+    "when suddenly",
+    "just as",
+    "whereas",
+    "meanwhile",
+    "and that's when"
+  ],
+  "hit": [
+    [
+      "has thoughtfully smashed his face",
+      "slammed his nose with the heel",
+      "caressed his cheek",
+      "bluntly bit his nose",
+      "desparately punched his eyebrow",
+      "stroked his eye",
+      "made a quick punch in his throat",
+      "poked a finger in his mouth",
+      "punched his forehead with all the dope",
+      "slapped him from all nonsense",
+      "poked a finger in his eye"
     ],
-    "ru": [
-      "бешеный",
-      "опасный",
-      "злой",
-      "психованный",
-      "дикий",
-      "взбешенный",
-      "дерзкий",
-      "наглый",
-      "бесстыжий",
-      "смелый",
-      "разъяренный",
-      "вероломный",
-      "коварный",
-      "хитрый",
-      "ловкий",
-      "озорной",
-      "безнравственный",
-      "грубый",
-      "гадкий",
-      "робкий",
-      "стеснительный"
-    ]
-  },
-  "blocked": {
-    "en": [
-      "skillfully blocked the hit",
-      "masterfully avoided the blow",
-      "stepped back to avoid the hit",
-      "quickly dodged",
-      "rapidly darted away",
-      "cautiously rushed away",
-      "anticipated it and was able to get away with no damage",
-      "forsaw it and managed to end up without a scratch"
+    [
+      "quickly hit in the pit of his stomach",
+      "made a double somersault and hit his chest",
+      "shamelessly pinched his nipples",
+      "cunningly poked a finger in his navel",
+      "made a thourough punch in his back",
+      "neatly made a punch in his heart"
     ],
-    "ru": [
-      "искусно заблокировал удар",
-      "мастерски избежал атаки",
-      "отступил чтобы избежать трагедии",
-      "быстро улонился",
-      "стремтельно увернулся",
-      "аккуратно извернулся",
-      "предвидел атаку и смог избежеть урона",
-      "ожидал атаку и смог отделаться царапиной"
+    [
+      "subtly made a hit in the legs",
+      "heartlessly broke his knee",
+      "grossly bit opponent's <censored>",
+      "gently caressed his toe",
+      "unthinkingly stepped on his foot",
+      "cowardly damaged his <censored>",
+      "rudely bit his ankle",
+      "shamelessly scratched his shin",
+      "jauntily poked a finger in his <censored>"
     ]
-  },
-  "but": {
-    "en": [
-      "but",
-      "when",
-      "when suddenly",
-      "just as",
-      "whereas",
-      "meanwhile",
-      "and that's when"
+  ],
+  "lookingForOpponent": [
+    "is looking for an opponent",
+    "wants to fight",
+    "wants to participate in a combat",
+    "is searching for a victim",
+    "is ready to fight"
+  ],
+  "missed": [
+    "awkwardly missed",
+    "lubberly slipped and wasn't able to hit",
+    "got distracted and fell asleep",
+    "uncouthly sprained the ankle and missed"
+  ],
+  "said": [
+    "misteriously whispered to",
+    "mumbled to",
+    "whispered to",
+    "smiling wildly told",
+    "made a grin and told",
+    "said shyly to"
+  ],
+  "toHit": [
+    [
+      "to punch the opponent in the face",
+      "to smash the opponent's face",
+      "to slam the enemy's nose with his heel",
+      "to caress opponent's cheek",
+      "to punch the competitor's eyebrow",
+      "to stroke the enemy's eye",
+      "to bite competitor's nose",
+      "to make a quick punch in the rival's throat",
+      "to poke a finger in the opponent's mouth",
+      "to punch the competitor's forehead",
+      "to slap the enemy",
+      "to poke a finger in the rival's eye"
     ],
-    "ru": [
-      "но",
-      "как вдруг",
-      "когда",
-      "в то время как",
-      "но тут"
-    ]
-  },
-  "hit": {
-    "en": [
-      [
-        "has thoughtfully smashed his face",
-        "slammed his nose with the heel",
-        "caressed his cheek",
-        "bluntly bit his nose",
-        "desparately punched his eyebrow",
-        "stroked his eye",
-        "made a quick punch in his throat",
-        "poked a finger in his mouth",
-        "punched his forehead with all the dope",
-        "slapped him from all nonsense",
-        "poked a finger in his eye"
-      ],
-      [
-        "quickly hit in the pit of his stomach",
-        "made a double somersault and hit his chest",
-        "shamelessly pinched his nipples",
-        "cunningly poked a finger in his navel",
-        "made a thourough punch in his back",
-        "neatly made a punch in his heart"
-      ],
-      [
-        "subtly made a hit in the legs",
-        "heartlessly broke his knee",
-        "grossly bit opponent's <censored>",
-        "gently caressed his toe",
-        "unthinkingly stepped on his foot",
-        "cowardly damaged his <censored>",
-        "rudely bit his ankle",
-        "shamelessly scratched his shin",
-        "jauntily poked a finger in his <censored>"
-      ]
+    [
+      "to hit in the pit of the opponent's stomach",
+      "to hit the chest of the enemy",
+      "to pinch the opponent's nipples",
+      "to poke a finger in the navel of the enemy",
+      "to make a punch in the competitor's back"
     ],
-    "ru": [
-      [
-        "вдумчиво вмазал ему по лицу",
-        "стукнул в его нос пяткой",
-        "погладил его по щеке",
-        "резко укусил его за нос",
-        "непрезойдено треснул ему в бровь",
-        "влепил ему в глаз",
-        "вцепился в горло противника",
-        "засунул палец врагу в рот",
-        "вмазал ему по лбу со всей дури",
-        "сделал сильную пощечину",
-        "ткнул пальцем в глаз"
-      ],
-      [
-        "быстро щелкнул его поддых",
-        "сделал двойное сальто и ударил противника в грудь",
-        "бесстыже ущипнул врага за соски",
-        "коварно ткнул пальцем в пупок",
-        "основательно вдарил противнику по спине",
-        "искусно провел удар в сердце"
-      ],
-      [
-        "незамето вломил ему по ногам",
-        "бессердечно сломал ему колено",
-        "вульгарно вмазал ему по <цензура>",
-        "нежно провел ему по пальцу на ноге",
-        "бездумно наступил противнику на ногу",
-        "трусливо вцепился противнику в <цензура>",
-        "грубо ударил ему по голени",
-        "бесстыже укусил его за голень",
-        "весело засунул палец в <цензура> врага"
-      ]
+    [
+      "to make a hit in the opponent's legs",
+      "to brake the enemy's knee",
+      "to wound the rival's toe",
+      "to hit opponent's <censored>",
+      "to step on the competitor's foot",
+      "to damage the opponent's <censored>",
+      "to rudely bit the rival's ankle",
+      "to scratch the enemy's shin"
     ]
-  },
-  "lookingForOpponent": {
-    "en": [
-      "is looking for an opponent",
-      "wants to fight",
-      "wants to participate in a combat",
-      "is searching for a victim",
-      "is ready to fight"
-    ],
-    "ru": [
-      "ищет противника",
-      "хочет подраться",
-      "хочет пооучавстовать в драке",
-      "испытывает зуд в кулахак",
-      "разыскивает жертву",
-      "готов к бою"
-    ]
-  },
-  "missed": {
-    "en": [
-      "awkwardly missed",
-      "lubberly slipped and wasn't able to hit",
-      "got distracted and fell asleep",
-      "uncouthly sprained the ankle and missed"
-    ],
-    "ru": [
-      "неуклюже промахнулся",
-      "глупо промазал",
-      "неумело подскользнулся и не смог нанести удар",
-      "отвлекся и уснул",
-      "подвернул лодыжку и промазал"
-    ]
-  },
-  "said": {
-    "en": [
-      "misteriously whispered to",
-      "mumbled to",
-      "whispered to",
-      "smiling wildly told",
-      "made a grin and told",
-      "said shyly to"
-    ],
-    "ru": [
-      "таинственно прошептал",
-      "промямлил",
-      "прошептал",
-      "широко улыбаясь сообщил",
-      "ухмыльнулся и сказал",
-      "смеренно пролепетал"
-    ]
-  },
-  "toHit": {
-    "en": [
-      [
-        "to punch the opponent in the face",
-        "to smash the opponent's face",
-        "to slam the enemy's nose with his heel",
-        "to caress opponent's cheek",
-        "to punch the competitor's eyebrow",
-        "to stroke the enemy's eye",
-        "to bite competitor's nose",
-        "to make a quick punch in the rival's throat",
-        "to poke a finger in the opponent's mouth",
-        "to punch the competitor's forehead",
-        "to slap the enemy",
-        "to poke a finger in the rival's eye"
-      ],
-      [ 
-        "to hit in the pit of the opponent's stomach",
-        "to hit the chest of the enemy",
-        "to pinch the opponent's nipples",
-        "to poke a finger in the navel of the enemy",
-        "to make a punch in the competitor's back"
-      ],
-      [
-        "to make a hit in the opponent's legs",
-        "to brake the enemy's knee",
-        "to wound the rival's toe",
-        "to hit opponent's <censored>",
-        "to step on the competitor's foot",
-        "to damage the opponent's <censored>",
-        "to rudely bit the rival's ankle",
-        "to scratch the enemy's shin"
-      ]
-    ],
-    "ru": [
-      [
-        "вдумчиво вмазать ему по лицу",
-        "стукнуть в его нос пяткой",
-        "погладить его по щеке",
-        "резко укусить его за нос",
-        "непрезойдено треснуть ему в бровь",
-        "влепить ему в глаз",
-        "вцепиться в горло противника",
-        "засунуть палец врагу в рот",
-        "вмазать ему по лбу со всей дури",
-        "сделать сильную пощечину",
-        "ткнуть пальцем в глаз"
-      ],
-      [
-        "быстро щелкнуть его поддых",
-        "сделать двойное сальто и ударить противника в грудь",
-        "бесстыже ущипнуть врага за соски",
-        "коварно ткнуть пальцем в пупок",
-        "основательно вдарить противники по спине",
-        "искусно провести удар в сердце"
-      ],
-      [
-        "незамето вломить ему по ногам",
-        "бессердечно сломать ему колено",
-        "вульгарно вмазать ему по <цензура>",
-        "нежно провести ему по пальцу на ноге",
-        "бездумно наступить противнику на ногу",
-        "трусливо вцепиться противнику в <цензура>",
-        "грубо ударить ему по голени",
-        "бесстыже укусить его за голень",
-        "весело засунуть палец в <цензура> врага"
-      ]
-    ]
-  },
-  "wasDoingSomething": {
-    "en": [
-      "blinked",
-      "chocked",
-      "closed his eyes",
-      "saw a pretty person far away",
-      "shed a tear",
-      "sneezed",
-      "was coughing",
-      "was feeling dizzy",
-      "was feeling tired",
-      "was having a silly smile",
-      "was hesitating",
-      "was itching his <censored>",
-      "was itching his navel",
-      "was picking his teeth",
-      "was scratching his back",
-      "was staring at the ceiling",
-      "was thinking about justice in the world",
-      "was too self confident",
-      "was trying to get rid of a fly",
-      "was trying to make a hit",
-      "was waiting for a hit"
-    ],
-    "ru": [
-      "моргнул",
-      "подавился",
-      "закрыл глаза",
-      "где-то в далеке увидел симпатичную особь противоположного пола",
-      "всплакнул",
-      "чихнул",
-      "откашлялся",
-      "испытал головкуржение",
-      "утомился",
-      "глупо улыбался",
-      "сомневался",
-      "чесал свои <цензура>",
-      "чесал пупок",
-      "ковырялся в зубах",
-      "почесывал спину",
-      "пялился в потолок",
-      "задумался о справделивости во всем мире",
-      "был слишком самоуверен",
-      "отмахивался от мухи",
-      "пытался нанести удар",
-      "ждал атаку"
-    ]
-  },
-  "wasTrying": {
-    "en": [
-      "was trying",
-      "attempted",
-      "made an effort",
-      "strived",
-      "decided",
-      "struggled",
-      "did his best"
-    ],
-    "ru": [
-      "пытался",
-      "старался",
-      "решил",
-      "делал все возможное чтобы",
-      "изо всех стил старался",
-      "пробовал",
-      "норовил"
-    ]
-  },
-  "when": {
-    "en": [
-      "and at the same time",
-      "and that's when",
-      "just as",
-      "meanwhile",
-      "when out of nowhere",
-      "when suddenly",
-      "when",
-      "whereas"
-    ],
-    "ru": [
-      "и тогда",
-      "и тогда вдруг",
-      "и тут вдруг",
-      "и тут",
-      "в то время как",
-      "и в это же время",
-      "когда вдруг",
-      "как вдруг"
-    ]
-  },
-  "won": {
-    "en": [
-      "has won against",
-      "has defeated",
-      "has beaten",
-      "has overcome"
-    ],
-    "ru": [
-      "победил",
-      "одержал победу",
-      "побил",
-      "одолел"
-    ]
-  }
+  ],
+  "wasDoingSomething": [
+    "blinked",
+    "chocked",
+    "closed his eyes",
+    "saw a pretty person far away",
+    "shed a tear",
+    "sneezed",
+    "was coughing",
+    "was feeling dizzy",
+    "was feeling tired",
+    "was having a silly smile",
+    "was hesitating",
+    "was itching his <censored>",
+    "was itching his navel",
+    "was picking his teeth",
+    "was scratching his back",
+    "was staring at the ceiling",
+    "was thinking about justice in the world",
+    "was too self confident",
+    "was trying to get rid of a fly",
+    "was trying to make a hit",
+    "was waiting for a hit"
+  ],
+  "wasTrying": [
+    "was trying",
+    "attempted",
+    "made an effort",
+    "strived",
+    "decided",
+    "struggled",
+    "did his best"
+  ],
+  "when": [
+    "and at the same time",
+    "and that's when",
+    "just as",
+    "meanwhile",
+    "when out of nowhere",
+    "when suddenly",
+    "when",
+    "whereas"
+  ],
+  "won": [
+    "has won against",
+    "has defeated",
+    "has beaten",
+    "has overcome"
+  ]
 }

--- a/text/combats.json
+++ b/text/combats.json
@@ -22,25 +22,8 @@
     "timid",
     "shy"
   ],
-  "blocked": [
-    "skillfully blocked the hit",
-    "masterfully avoided the blow",
-    "stepped back to avoid the hit",
-    "quickly dodged",
-    "rapidly darted away",
-    "cautiously rushed away",
-    "anticipated it and was able to get away with no damage",
-    "forsaw it and managed to end up without a scratch"
-  ],
-  "but": [
-    "but",
-    "when",
-    "when suddenly",
-    "just as",
-    "whereas",
-    "meanwhile",
-    "and that's when"
-  ],
+  
+  
   "hit": [
     [
       "has thoughtfully smashed his face",
@@ -82,53 +65,9 @@
     "is searching for a victim",
     "is ready to fight"
   ],
-  "missed": [
-    "awkwardly missed",
-    "lubberly slipped and wasn't able to hit",
-    "got distracted and fell asleep",
-    "uncouthly sprained the ankle and missed"
-  ],
-  "said": [
-    "misteriously whispered to",
-    "mumbled to",
-    "whispered to",
-    "smiling wildly told",
-    "made a grin and told",
-    "said shyly to"
-  ],
-  "toHit": [
-    [
-      "to punch the opponent in the face",
-      "to smash the opponent's face",
-      "to slam the enemy's nose with his heel",
-      "to caress opponent's cheek",
-      "to punch the competitor's eyebrow",
-      "to stroke the enemy's eye",
-      "to bite competitor's nose",
-      "to make a quick punch in the rival's throat",
-      "to poke a finger in the opponent's mouth",
-      "to punch the competitor's forehead",
-      "to slap the enemy",
-      "to poke a finger in the rival's eye"
-    ],
-    [
-      "to hit in the pit of the opponent's stomach",
-      "to hit the chest of the enemy",
-      "to pinch the opponent's nipples",
-      "to poke a finger in the navel of the enemy",
-      "to make a punch in the competitor's back"
-    ],
-    [
-      "to make a hit in the opponent's legs",
-      "to brake the enemy's knee",
-      "to wound the rival's toe",
-      "to hit opponent's <censored>",
-      "to step on the competitor's foot",
-      "to damage the opponent's <censored>",
-      "to rudely bit the rival's ankle",
-      "to scratch the enemy's shin"
-    ]
-  ],
+  
+  
+  
   "wasDoingSomething": [
     "blinked",
     "chocked",
@@ -152,15 +91,7 @@
     "was trying to make a hit",
     "was waiting for a hit"
   ],
-  "wasTrying": [
-    "was trying",
-    "attempted",
-    "made an effort",
-    "strived",
-    "decided",
-    "struggled",
-    "did his best"
-  ],
+  
   "when": [
     "and at the same time",
     "and that's when",

--- a/text/misc.json
+++ b/text/misc.json
@@ -1,6 +1,3 @@
 {
-  "joinedTheFightClub": {
-    "en": "joined the Fight Club!",
-    "ru": "присоединился к Бойцовскому Клубу!"
-  }
+  "joinedTheFightClub": "ist dem Fight Club beigetreten!"
 }

--- a/text/wise.json
+++ b/text/wise.json
@@ -1,54 +1,18 @@
 {
-  "wisdomIntro": {
-    "en": [
-      "The old man ignores you for an hour, but then suddenly groans:",
-      "When you approached the old man's home, it was empty. You found a note left for someone:",
-      "The wiseman is looking at you with contempt:",
-      "The wizard wasn't in a good mood today, he shouts at you:"
-    ],
-    "de": [
-      "Der weise Mann ignoriert dich eine Stunde lang, dann stöhnt er plötzlich:",
-      "Als du dich der Hütte des Weisen nähertest, war sie leer. Du fandst eine hinterlassene Notiz:",
-      "Der Weise blickt dich verächtlich an:",
-      "Der Zauberer ist heute schlechter Laune und fährt dich an:"
-    ],
-    "ru": [
-      "Старец игноирует тебя в течение часа, как вдруг говорит:",
-      "Когда ты подошел к дому старца, он был пуст. Ты нашел записку:",
-      "Мудрец смотрит на тебя с презрением:",
-      "Старец сегодня в дурном расположении духа, он кричит на тебя:"
-    ]
-  },
-  "wisdoms": {
-    "en": [
-      "There is an ancient story about a man... He had a very silly name. Once he typed `/username God` and became a God.",
-      "There is: a legend about two fighters, they were skilfull and clever, but didn't know how to talk to each other. Once one of them started typing a message during the fight and it was sent to the opponent, and the opponent only. And so fighters began to talk",
-      "Do you hear the voices sometimes? I do, everybody does. Gods once told me that you can hear them only if you were active in the last few minutes. If you go away - the voices will leave you alone as well.",
-      "Once upon a time there was a fighter of incredible strength. They say he could defeat any opponent with a single hit.",
-      "Not many of us still remember, but once there lived a great warrior. Thousands tried to kill him, but nobody could. They say the secret was set in his incredible vitality.",
-      "Have you ever thought what luck really is? Some consider that a lucky person acts first, others think that a lucky person is more likely to make a perfect painful hit.",
-      "The Gods? There are two of them I heard, one has a very long beard and another one is very smart. Well, Gods are always smart, arent't they?",
-      "Have you ever seen a healing potion? They are very rare when fighting regular folks. I've heard one can acquire them for sure after winning a real opponent. Rumor has it, those who have found them were able to beat far more superior enemies."
-    ],
-    "de": [
-      "Es gibt eine uralte Geschichte über einen Mann … Er trug einen sehr törichten Namen. Eines Tages tippte er `/username Gott` und wurde zu einem Gott.",
-      "Es heißt: Es gab zwei Kämpfer, geschickt und klug, doch sie wussten nicht, wie sie miteinander sprechen sollten. Einst schrieb einer von ihnen mitten im Gefecht eine Nachricht – sie ging nur an den Gegner. Und so begannen die Kämpfer, miteinander zu reden.",
-      "Hörst du manchmal die Stimmen? Ich höre sie, alle hören sie. Die Götter sagten mir einst, man vernimmt sie nur, wenn man in den letzten Minuten aktiv war. Gehst du weg, verstummen die Stimmen ebenfalls.",
-      "Es war einmal ein Kämpfer von unglaublicher Stärke. Man sagt, er konnte jeden Gegner mit einem einzigen Schlag bezwingen.",
-      "Nur wenige erinnern sich noch, doch einst lebte ein großer Krieger. Tausende versuchten, ihn zu töten, doch niemand schaffte es. Sein Geheimnis, so sagt man, lag in seiner erstaunlichen Zähigkeit.",
-      "Hast du je darüber nachgedacht, was Glück wirklich ist? Manche sagen, ein Glückspilz handelt zuerst, andere glauben, er trifft mit größerer Wahrscheinlichkeit einen perfekten, schmerzhaften Schlag.",
-      "Die Götter? Ich hörte, es gibt zwei: Der eine trägt einen sehr langen Bart, der andere ist sehr klug. Nun, Götter sind immer klug, nicht wahr?",
-      "Hast du je einen Heiltrank gesehen? Unter gewöhnlichen Leuten im Kampf sind sie sehr selten. Man munkelt, man könne ihn sicher erhalten, wenn man einen echten Gegner besiegt. Und wer ihn besitzt, so sagt die Kunde, kann weit überlegene Feinde bezwingen."
-    ],
-    "ru": [
-      "Я поведаю тебя историю о девушке... У нее было очень глупое имя. Однажды она написала `/username Богиня` и стала Богиней.",
-      "Есть легенда о двух воинах: они были искусны и умелы, но не могли говорить друг с другом. Однажды, один из них стал писать сообщение во время боя. Это сообщение было отправлено противнику и только ему. Так воины начали говорить друг с другом наедине.",
-      "Ты слышишь голоса иногда? Я слышу. Все слышат. Боги однажды сказали мне, что мы можем их слышать только если мы были активны в течение последних минут. Если мы отвлечемся - голоса оставят нас в покое.",
-      "Однажды жил был боец неведомой силы. Говорят, что он мог сразить любого с одного удара.",
-      "Немногие помнят, но однажды жил был великий воин. Тысячи пытались убить его, но никто не мог. Говорят, его секрет был в большой живучести.",
-      "Ты когда-нибудь думала, что такое удача? Некоторые думают, что удача это когда ты действуешь первым, другие - что у тебя больше шанса сделать критический удар во время боя.",
-      "Боги? Я слышал о трех. У одного была очень длинная борода, второй был очень умен, а третий славился искусным оратором. Боги всегда безукоризнены, не так ли?",
-      "Ты когда-нибудь видела целебное зелье? Они очень редки когда дерешься с кем попало. Я слышал ты можешь получить его если выиграешь бой у другого человека. Ходит слух, что тот кто обладает ими, может победить более умелых протиников."
-    ]
-  }
+  "wisdomIntro": [
+    "Der weise Mann ignoriert dich eine Stunde lang, dann stöhnt er plötzlich:",
+    "Als du dich der Hütte des Weisen nähertest, war sie leer. Du fandst eine hinterlassene Notiz:",
+    "Der Weise blickt dich verächtlich an:",
+    "Der Zauberer ist heute schlechter Laune und fährt dich an:"
+  ],
+  "wisdoms": [
+    "Es gibt eine uralte Geschichte über einen Mann … Er trug einen sehr törichten Namen. Eines Tages tippte er `/username Gott` und wurde zu einem Gott.",
+    "Es heißt: Es gab zwei Kämpfer, geschickt und klug, doch sie wussten nicht, wie sie miteinander sprechen sollten. Einst schrieb einer von ihnen mitten im Gefecht eine Nachricht – sie ging nur an den Gegner. Und so begannen die Kämpfer, miteinander zu reden.",
+    "Hörst du manchmal die Stimmen? Ich höre sie, alle hören sie. Die Götter sagten mir einst, man vernimmt sie nur, wenn man in den letzten Minuten aktiv war. Gehst du weg, verstummen die Stimmen ebenfalls.",
+    "Es war einmal ein Kämpfer von unglaublicher Stärke. Man sagt, er konnte jeden Gegner mit einem einzigen Schlag bezwingen.",
+    "Nur wenige erinnern sich noch, doch einst lebte ein großer Krieger. Tausende versuchten, ihn zu töten, doch niemand schaffte es. Sein Geheimnis, so sagt man, lag in seiner erstaunlichen Zähigkeit.",
+    "Hast du je darüber nachgedacht, was Glück wirklich ist? Manche sagen, ein Glückspilz handelt zuerst, andere glauben, er trifft mit größerer Wahrscheinlichkeit einen perfekten, schmerzhaften Schlag.",
+    "Die Götter? Ich hörte, es gibt zwei: Der eine trägt einen sehr langen Bart, der andere ist sehr klug. Nun, Götter sind immer klug, nicht wahr?",
+    "Hast du je einen Heiltrank gesehen? Unter gewöhnlichen Leuten im Kampf sind sie sehr selten. Man munkelt, man könne ihn sicher erhalten, wenn man einen echten Gegner besiegt. Und wer ihn besitzt, so sagt die Kunde, kann weit überlegene Feinde bezwingen."
+  ]
 }


### PR DESCRIPTION
Remove multi-language support, standardizing game text to German with English fallback.

This simplifies the codebase by eliminating the language switching system and associated data structures, as the game was only partially localized. Texts are now directly German, falling back to English if German is not available.

---
<a href="https://cursor.com/background-agent?bcId=bc-da392c82-d432-4935-b4ca-e9580e7c648d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da392c82-d432-4935-b4ca-e9580e7c648d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

