### PR TITLE
Treat battle timeout as fail action

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -202,8 +202,15 @@ public class Main {
       Client opponent = Storage.getClientByChatId(client.fightingChatId);
       Messenger.send(client.chatId, "Timeout!");
       Messenger.send(opponent.chatId, "Timeout!");
-      finishFight(opponent, client);
+      // Reset timeout warning and activity since we're handling the timeout
+      client.lastFightActivitySince = curTimeSeconds;
+      client.timeoutWarningSent = false;
+      // Timeout acts the same as pressing "Fail" - handle as failed task
+      handleHitTask(client, opponent, false);
       Storage.saveClients(opponent, client);
+      if (opponent.chatId < 0 && opponent.status == Client.Status.FIGHTING) {
+        activateBotTask(opponent);
+      }
     }
   }
 
@@ -515,7 +522,7 @@ public class Main {
 
   private static void askTaskStatus(Client client) {
     Messenger.send(client.chatId, "Attempt at solving an exercise and report feedback",
-        new String[] { TASK_FAIL, TASK_SUCCESS });
+        addPotions(client, new String[] { TASK_SUCCESS }));
   }
 
   private static String[] addPotions(Client client, String[] options) {
@@ -563,7 +570,7 @@ public class Main {
             PhraseGenerator.attackToOffender(client,
                 victim,
                 clientHits),
-        addPotions(client, new String[] { TASK_FAIL, TASK_SUCCESS }),
+        addPotions(client, new String[] { TASK_SUCCESS }),
         true);
   }
 


### PR DESCRIPTION
Modify battle timeout to result in a failed attack instead of an instant loss, and remove the 'Fail' button from the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-68612564-22e8-42bc-a60b-d79c8b6c1b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68612564-22e8-42bc-a60b-d79c8b6c1b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

