### PR TITLE
Add cursor build and test validation rule

### DIFF
--- a/.cursor/rules/build_validation.mdc
+++ b/.cursor/rules/build_validation.mdc
@@ -29,6 +29,7 @@ globs: ['**/*.java', '**/build.sh', '**/run*.sh']
 - All existing tests must continue to pass
 - New functionality should include appropriate tests
 - Use assertions (`-ea` flag is enabled) for runtime validation
+- **No compiled files in version control**: Ensure no `.class` files are included in diffs or commits - only source code should be tracked
 
 ## Dependencies
 - Project uses Gson 2.8.6 library (`lib/gson-2.8.6.jar`)

--- a/.cursor/rules/build_validation.mdc
+++ b/.cursor/rules/build_validation.mdc
@@ -1,38 +1,41 @@
-# Cursor Rules for Java Project
+---
+description: Enforce build and test validation using build.sh for Java project
+globs: ['**/*.java', '**/build.sh', '**/run*.sh']
+---
 
-## Build and Test Validation
+# Build and Test Validation Rules
 
-### Use build.sh for validation
+## Use build.sh for validation
 - Before making any code changes that could affect compilation or tests, run `./build.sh` to validate the current state
 - After making code changes, always run `./build.sh` to ensure:
   1. The code compiles successfully
   2. All tests pass
   3. The build completes without errors
 
-### Build Script Requirements
+## Build Script Requirements
 - The `build.sh` script handles both compilation and test execution
 - It compiles Java files to `build/classes` directory
 - It runs the test suite using `ClientTest` class
 - Exit code 0 indicates success, non-zero indicates failure
 
-### Validation Process
+## Validation Process
 1. **Before Changes**: Run `./build.sh` to establish baseline
 2. **After Changes**: Run `./build.sh` to validate changes
 3. **Error Handling**: If build fails, fix compilation errors before proceeding
 4. **Test Failures**: If tests fail, address test failures before considering changes complete
 
-### Code Quality Standards
+## Code Quality Standards
 - All Java files must compile without warnings when possible
 - All existing tests must continue to pass
 - New functionality should include appropriate tests
 - Use assertions (`-ea` flag is enabled) for runtime validation
 
-### Dependencies
+## Dependencies
 - Project uses Gson 2.8.6 library (`lib/gson-2.8.6.jar`)
 - Classpath includes both compiled classes and external libraries
 - Cross-platform compatibility maintained for Windows, macOS, and Linux
 
-### Usage Examples
+## Usage Examples
 ```bash
 # Validate before starting work
 ./build.sh

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,51 @@
+# Cursor Rules for Java Project
+
+## Build and Test Validation
+
+### Use build.sh for validation
+- Before making any code changes that could affect compilation or tests, run `./build.sh` to validate the current state
+- After making code changes, always run `./build.sh` to ensure:
+  1. The code compiles successfully
+  2. All tests pass
+  3. The build completes without errors
+
+### Build Script Requirements
+- The `build.sh` script handles both compilation and test execution
+- It compiles Java files to `build/classes` directory
+- It runs the test suite using `ClientTest` class
+- Exit code 0 indicates success, non-zero indicates failure
+
+### Validation Process
+1. **Before Changes**: Run `./build.sh` to establish baseline
+2. **After Changes**: Run `./build.sh` to validate changes
+3. **Error Handling**: If build fails, fix compilation errors before proceeding
+4. **Test Failures**: If tests fail, address test failures before considering changes complete
+
+### Code Quality Standards
+- All Java files must compile without warnings when possible
+- All existing tests must continue to pass
+- New functionality should include appropriate tests
+- Use assertions (`-ea` flag is enabled) for runtime validation
+
+### Dependencies
+- Project uses Gson 2.8.6 library (`lib/gson-2.8.6.jar`)
+- Classpath includes both compiled classes and external libraries
+- Cross-platform compatibility maintained for Windows, macOS, and Linux
+
+### Usage Examples
+```bash
+# Validate before starting work
+./build.sh
+
+# Validate after making changes
+./build.sh
+
+# Check exit code programmatically
+./build.sh && echo "Build successful" || echo "Build failed"
+```
+
+## Additional Guidelines
+- Always test changes locally using `build.sh` before committing
+- If `build.sh` fails, investigate and fix issues immediately
+- Maintain the build script's cross-platform compatibility
+- Keep the test suite comprehensive and up-to-date


### PR DESCRIPTION
Add a `.cursorrules` file to enforce using `build.sh` for consistent build and test validation.

This rule ensures that `build.sh` is used consistently to validate successful compilation, passing tests, and overall build completion, serving as the single source of truth for codebase health.

---
<a href="https://cursor.com/background-agent?bcId=bc-842a4ddd-61e7-4bfd-97f5-647086d26822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-842a4ddd-61e7-4bfd-97f5-647086d26822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

