### PR TITLE
Fix healing potion count display bug

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -676,7 +676,7 @@ public class Main {
         client.getItemNum(Game.Item.HPOTION) + " übrig. " +
         "[" + client.hp + "/" + client.getMaxHp() + "]";
     if (client.status == Client.Status.FIGHTING) {
-      Messenger.send(client.chatId, clientMsg);
+      Messenger.send(client.chatId, clientMsg, addPotions(client, new String[] { TASK_SUCCESS }));
       Client opponent = Storage.getClientByChatId(client.fightingChatId);
       Messenger.send(opponent.chatId, "\uD83C\uDF76 " + client.username + " hat einen Heiltrank konsumiert " +
           "[" + client.hp + "/" + client.getMaxHp() + "]");


### PR DESCRIPTION
Update healing potion button count in combat after consumption.

The `consumePotion` method was not refreshing the combat buttons after a potion was used, leading to the button displaying an outdated potion count. This change ensures the combat buttons are re-rendered with the correct potion count after consumption.

---
<a href="https://cursor.com/background-agent?bcId=bc-7075be88-0bb8-4908-95e5-c7a60d011a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7075be88-0bb8-4908-95e5-c7a60d011a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

