### PR TITLE
Adjust bot attack order based on luck

### DIFF
--- a/ClientTest.java
+++ b/ClientTest.java
@@ -11,7 +11,6 @@ public class ClientTest {
         allTestsPassed &= testProfileDisplayWithNoBrewingOptions();
         allTestsPassed &= testProfileDisplayWithSingleBrewingOption();
         allTestsPassed &= testProfileDisplayWithMultipleBrewingOptions();
-        allTestsPassed &= testLuckBasedTurnOrder();
         if (!allTestsPassed) {
             System.exit(1); 
         }
@@ -322,76 +321,6 @@ public class ClientTest {
             "Message should mention Stärketrank");
         allTestsPassed &= assertEquals(1, messageContains(display.message, "Glückstrank") ? 1 : 0,
             "Message should mention Glückstrank");
-        
-        return allTestsPassed;
-    }
-    
-    public static boolean testLuckBasedTurnOrder() {
-        boolean allTestsPassed = true;
-        
-        // Test with equal luck values (should be roughly 50/50)
-        Client player = new Client(1, "Player");
-        Client bot = new Client(-1, "Bot");
-        player.luck = 3;
-        bot.luck = 3;
-        
-        // Run multiple tests to check distribution
-        int playerFirstCount = 0;
-        int botFirstCount = 0;
-        int totalTests = 1000;
-        
-        // We need to test the determineTurnOrder method through reflection
-        // since it's private, or we can test the overall behavior
-        for (int i = 0; i < totalTests; i++) {
-            // Create fresh clients for each test
-            Client testPlayer = new Client(1, "Player");
-            Client testBot = new Client(-1, "Bot");
-            testPlayer.luck = 3;
-            testBot.luck = 3;
-            
-            // Test the turn order by simulating a fight preparation
-            // Since we can't access the private method directly, we'll test indirectly
-            // by checking if the system uses luck-based randomness
-            
-            // For equal luck (3 vs 3), bot should win about 50% of the time
-            int totalLuck = testPlayer.luck + testBot.luck;
-            int randomValue = Utils.rndInRange(1, totalLuck);
-            if (randomValue <= testBot.luck) {
-                botFirstCount++;
-            } else {
-                playerFirstCount++;
-            }
-        }
-        
-        // With equal luck, both should get roughly equal chances (allow 10% variance)
-        double botPercentage = (double) botFirstCount / totalTests;
-        allTestsPassed &= assertEquals(1, (botPercentage >= 0.4 && botPercentage <= 0.6) ? 1 : 0,
-            "With equal luck (3 vs 3), bot should go first about 50% of the time. Actual: " + String.format("%.2f%%", botPercentage * 100));
-        
-        // Test with unequal luck values
-        playerFirstCount = 0;
-        botFirstCount = 0;
-        
-        for (int i = 0; i < totalTests; i++) {
-            Client testPlayer = new Client(1, "Player");
-            Client testBot = new Client(-1, "Bot");
-            testPlayer.luck = 6;  // Player has higher luck
-            testBot.luck = 3;     // Bot has lower luck
-            
-            // Bot should have 3/(3+6) = 33.33% chance to go first
-            int totalLuck = testPlayer.luck + testBot.luck;
-            int randomValue = Utils.rndInRange(1, totalLuck);
-            if (randomValue <= testBot.luck) {
-                botFirstCount++;
-            } else {
-                playerFirstCount++;
-            }
-        }
-        
-        // Bot should go first about 33% of the time (allow 10% variance)
-        botPercentage = (double) botFirstCount / totalTests;
-        allTestsPassed &= assertEquals(1, (botPercentage >= 0.23 && botPercentage <= 0.43) ? 1 : 0,
-            "With luck 6 vs 3, bot should go first about 33% of the time. Actual: " + String.format("%.2f%%", botPercentage * 100));
         
         return allTestsPassed;
     }

--- a/ClientTest.java
+++ b/ClientTest.java
@@ -11,6 +11,7 @@ public class ClientTest {
         allTestsPassed &= testProfileDisplayWithNoBrewingOptions();
         allTestsPassed &= testProfileDisplayWithSingleBrewingOption();
         allTestsPassed &= testProfileDisplayWithMultipleBrewingOptions();
+        allTestsPassed &= testLuckBasedTurnOrder();
         if (!allTestsPassed) {
             System.exit(1); 
         }
@@ -321,6 +322,76 @@ public class ClientTest {
             "Message should mention Stärketrank");
         allTestsPassed &= assertEquals(1, messageContains(display.message, "Glückstrank") ? 1 : 0,
             "Message should mention Glückstrank");
+        
+        return allTestsPassed;
+    }
+    
+    public static boolean testLuckBasedTurnOrder() {
+        boolean allTestsPassed = true;
+        
+        // Test with equal luck values (should be roughly 50/50)
+        Client player = new Client(1, "Player");
+        Client bot = new Client(-1, "Bot");
+        player.luck = 3;
+        bot.luck = 3;
+        
+        // Run multiple tests to check distribution
+        int playerFirstCount = 0;
+        int botFirstCount = 0;
+        int totalTests = 1000;
+        
+        // We need to test the determineTurnOrder method through reflection
+        // since it's private, or we can test the overall behavior
+        for (int i = 0; i < totalTests; i++) {
+            // Create fresh clients for each test
+            Client testPlayer = new Client(1, "Player");
+            Client testBot = new Client(-1, "Bot");
+            testPlayer.luck = 3;
+            testBot.luck = 3;
+            
+            // Test the turn order by simulating a fight preparation
+            // Since we can't access the private method directly, we'll test indirectly
+            // by checking if the system uses luck-based randomness
+            
+            // For equal luck (3 vs 3), bot should win about 50% of the time
+            int totalLuck = testPlayer.luck + testBot.luck;
+            int randomValue = Utils.rndInRange(1, totalLuck);
+            if (randomValue <= testBot.luck) {
+                botFirstCount++;
+            } else {
+                playerFirstCount++;
+            }
+        }
+        
+        // With equal luck, both should get roughly equal chances (allow 10% variance)
+        double botPercentage = (double) botFirstCount / totalTests;
+        allTestsPassed &= assertEquals(1, (botPercentage >= 0.4 && botPercentage <= 0.6) ? 1 : 0,
+            "With equal luck (3 vs 3), bot should go first about 50% of the time. Actual: " + String.format("%.2f%%", botPercentage * 100));
+        
+        // Test with unequal luck values
+        playerFirstCount = 0;
+        botFirstCount = 0;
+        
+        for (int i = 0; i < totalTests; i++) {
+            Client testPlayer = new Client(1, "Player");
+            Client testBot = new Client(-1, "Bot");
+            testPlayer.luck = 6;  // Player has higher luck
+            testBot.luck = 3;     // Bot has lower luck
+            
+            // Bot should have 3/(3+6) = 33.33% chance to go first
+            int totalLuck = testPlayer.luck + testBot.luck;
+            int randomValue = Utils.rndInRange(1, totalLuck);
+            if (randomValue <= testBot.luck) {
+                botFirstCount++;
+            } else {
+                playerFirstCount++;
+            }
+        }
+        
+        // Bot should go first about 33% of the time (allow 10% variance)
+        botPercentage = (double) botFirstCount / totalTests;
+        allTestsPassed &= assertEquals(1, (botPercentage >= 0.23 && botPercentage <= 0.43) ? 1 : 0,
+            "With luck 6 vs 3, bot should go first about 33% of the time. Actual: " + String.format("%.2f%%", botPercentage * 100));
         
         return allTestsPassed;
     }

--- a/Main.java
+++ b/Main.java
@@ -836,7 +836,19 @@ public class Main {
     }
   }
 
+  // Determines who goes first based on luck values
+  // Returns 0 if client goes first, 1 if opponent goes first
+  private static int determineTurnOrder(Client client, Client opponent) {
+    int totalLuck = client.luck + opponent.luck;
+    int randomValue = Utils.rndInRange(1, totalLuck);
+    
+    // If random value is <= opponent's luck, opponent goes first
+    // Otherwise, client goes first
+    return (randomValue <= opponent.luck) ? 1 : 0;
+  }
+
   static void prepareToFight(Client client, Client opponent) {
-    prepareToFight(client, opponent, 0);
+    int turnOrder = determineTurnOrder(client, opponent);
+    prepareToFight(client, opponent, turnOrder);
   }
 }


### PR DESCRIPTION
Implement luck-based turn order for battles, making the bot's chance to attack first proportional to its luck relative to the player's luck.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca92d685-d088-4604-8b3d-47b937952f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca92d685-d088-4604-8b3d-47b937952f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

