### PR TITLE
Evaluate and remove profile display class

### DIFF
--- a/ClientTest.java
+++ b/ClientTest.java
@@ -204,7 +204,7 @@ public class ClientTest {
         client.nameChangeHintSent = true; // Avoid name change hint in message
         
         // Test profile display
-        Main.ProfileDisplay display = Main.buildProfileDisplay(client);
+        GameEngine.ProfileDisplay display = GameEngine.buildProfileDisplay(client);
         
         // Should have standard buttons only
         allTestsPassed &= assertEquals(3, display.buttons.length, 
@@ -238,7 +238,7 @@ public class ClientTest {
         client.giveItem(Game.Item.BOTTLE);
         
         // Test profile display
-        Main.ProfileDisplay display = Main.buildProfileDisplay(client);
+        GameEngine.ProfileDisplay display = GameEngine.buildProfileDisplay(client);
         
         // Should have main buttons + 1 brewing button
         allTestsPassed &= assertEquals(4, display.buttons.length, 
@@ -292,7 +292,7 @@ public class ClientTest {
         client.giveItem(Game.Item.SILVER);
         
         // Test profile display
-        Main.ProfileDisplay display = Main.buildProfileDisplay(client);
+        GameEngine.ProfileDisplay display = GameEngine.buildProfileDisplay(client);
         
         // Should have main buttons + 3 brewing buttons
         allTestsPassed &= assertEquals(6, display.buttons.length, 

--- a/Main.java
+++ b/Main.java
@@ -70,22 +70,6 @@ public class Main {
     gameEngine = new GameEngine(storage, telegram);
   }
 
-  // Testable class to hold profile display data - kept for backward compatibility with tests
-  static class ProfileDisplay {
-    String message;
-    String[] buttons;
-    
-    ProfileDisplay(String message, String[] buttons) {
-      this.message = message;
-      this.buttons = buttons;
-    }
-  }
-  
-  // Testable method that builds profile display without sending messages - kept for backward compatibility with tests
-  static ProfileDisplay buildProfileDisplay(Client client) {
-    GameEngine.ProfileDisplay engineDisplay = GameEngine.buildProfileDisplay(client);
-    return new ProfileDisplay(engineDisplay.message, engineDisplay.buttons);
-  }
 
   // Kept for backward compatibility with tests
   static void prepareToFight(Client client, Client opponent) {


### PR DESCRIPTION
Remove duplicate `ProfileDisplay` class and `buildProfileDisplay` method from `Main.java` to eliminate redundancy and standardize test usage.

The `Main.ProfileDisplay` class and `Main.buildProfileDisplay` method were redundant wrappers for `GameEngine.ProfileDisplay` and `GameEngine.buildProfileDisplay`, respectively, and were only kept for "backward compatibility with tests." This change removes the duplication and updates tests to directly use the `GameEngine` implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-487132d4-dc4f-456a-a149-ede9d9493db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-487132d4-dc4f-456a-a149-ede9d9493db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

