### PR TITLE
Investigate prod gemini integration failure

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -55,14 +55,16 @@ public class Main {
     }
     Logger.setDbPath(args[0]);
     Logger.initialize();
+    
+    // Set environment before initializing components that depend on it
+    if (args.length > 1 && args[1].equals("PROD")) {
+      isProd = true;
+    }
+    
     TelegramApi.initialize();
     Logger.log("test");
     Gemini.initialize();
     Phrases.initialize();
-
-    if (args.length > 1 && args[1].equals("PROD")) {
-      isProd = true;
-    }
 
     // Initialize the game engine
     StorageInterface storage = new Storage();


### PR DESCRIPTION
Reorder `isProd` environment detection to fix Gemini initialization in PROD.

Previously, `Gemini.initialize()` was called before the `isProd` flag was set, causing Gemini to incorrectly skip API key loading in PROD environments. This change ensures `isProd` is set first, allowing Gemini to initialize correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e129bca-ac41-4cce-a79c-c7543519264d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e129bca-ac41-4cce-a79c-c7543519264d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

