### PR TITLE
Expand item drop list for Aufgabe

### DIFF
--- a/GameEngine.java
+++ b/GameEngine.java
@@ -222,7 +222,7 @@ public class GameEngine {
                 }
                 return;
             }
-            Game.Item found = Utils.getRnd(new Game.Item[] { Game.Item.ASH, Game.Item.BANDAGE, Game.Item.BOTTLE });
+            Game.Item found = Utils.getRnd(Game.ITEM_VALUES);
             client.giveItem(found);
             storage.saveClient(client);
             String foundMsg = "";


### PR DESCRIPTION
Expand the item pool for 'Aufgabe' quests to include all game items.

Previously, players could only find a limited set of three items (ASH, BANDAGE, BOTTLE) when successfully completing an 'Aufgabe'. This change utilizes the `Game.ITEM_VALUES` array, allowing players to discover any of the 17 available items, significantly increasing item variety and player engagement.

---
<a href="https://cursor.com/background-agent?bcId=bc-4888898c-75e5-4279-b892-ae51be23c45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4888898c-75e5-4279-b892-ae51be23c45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

