### PR TITLE
Merge boss defeat and win messages

### DIFF
--- a/GameEngine.java
+++ b/GameEngine.java
@@ -747,7 +747,12 @@ public class GameEngine {
         
         // Build comprehensive victory message for the winner
         StringBuilder victoryMessage = new StringBuilder();
-        victoryMessage.append("Du hast gewonnen!");
+        try {
+            victoryMessage.append(PhraseGenerator.getWonPhrase(winner, loser));
+        } catch (Exception e) {
+            // Fallback to simple message in case of phrase generation errors
+            victoryMessage.append("Du hast gewonnen!");
+        }
         
         // Add experience information
         int winnerExpUntilPromo = winner.nextExp() - winner.exp;

--- a/GameEngineEndToEndTest.java
+++ b/GameEngineEndToEndTest.java
@@ -106,7 +106,7 @@ public class GameEngineEndToEndTest {
             engine.processUpdate(telegram.getUpdates(6 + round)[0]);
             
             // Check if fight is over (someone won)
-            if (telegram.hasMessageContaining("Du hast gewonnen!") || 
+            if (telegram.hasMessageContaining("Erfahrung erhalten") || 
                 telegram.hasMessageContaining("Du wurdest im Kampf besiegt")) {
                 testPassed &= true; // Fight ended properly
                 break;

--- a/VictoryMessageTest.java
+++ b/VictoryMessageTest.java
@@ -63,12 +63,12 @@ public class VictoryMessageTest {
             telegram.simulateUserMessage(activePlayer, "Player" + activePlayer, "Erfolg");
             engine.processUpdate(telegram.getUpdates(4 + round)[0]);
             
-            // Check if fight ended
-            if (telegram.hasMessageContaining("Du hast gewonnen!")) {
+            // Check if fight ended (look for victory phrases or experience gained)
+            if (telegram.hasMessageContaining("Erfahrung erhalten") || telegram.hasMessageContaining("hat") && telegram.hasMessageContaining("besiegt")) {
                 // Find the victory message
                 MockTelegram.SentMessage victoryMessage = null;
                 for (MockTelegram.SentMessage msg : telegram.getSentMessages()) {
-                    if (msg.message.contains("Du hast gewonnen!")) {
+                    if (msg.message.contains("Erfahrung erhalten")) {
                         victoryMessage = msg;
                         break;
                     }
@@ -78,7 +78,7 @@ public class VictoryMessageTest {
                     String message = victoryMessage.message;
                     
                     // Test 1: Check that all basic components are in the single message
-                    testPassed &= message.contains("Du hast gewonnen!");
+                    testPassed &= (message.contains("hat") && message.contains("besiegt")) || message.contains("☠");
                     testPassed &= message.contains("Erfahrung erhalten");
                     testPassed &= message.contains("Erfahrung fehlt bis zum Levelaufstieg");
                     testPassed &= message.contains("Heiltrank gefunden");
@@ -102,8 +102,7 @@ public class VictoryMessageTest {
                 int victoryMessageCount = 0;
                 for (MockTelegram.SentMessage msg : telegram.getSentMessages()) {
                     if (msg.chatId == activePlayer && 
-                        (msg.message.contains("Du hast gewonnen!") || 
-                         msg.message.contains("Erfahrung erhalten") ||
+                        (msg.message.contains("Erfahrung erhalten") ||
                          msg.message.contains("gefunden") ||
                          msg.message.contains("regenerieren"))) {
                         victoryMessageCount++;


### PR DESCRIPTION
Merge player victory messages into a single, consolidated message, replacing "Du hast gewonnen!" with the specific victory phrase.

Previously, players received two distinct messages upon winning a fight: a general victory phrase (e.g., "☠ lenny hat Dämon besiegt.") and a detailed summary starting with "Du hast gewonnen!". This PR combines these into one coherent message, improving the user experience by presenting all victory information together.

---
<a href="https://cursor.com/background-agent?bcId=bc-24df48d8-fa43-44bf-b6b5-cde68dbc3097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24df48d8-fa43-44bf-b6b5-cde68dbc3097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

