### PR TITLE
Remove duplicate battle victory messages

### DIFF
--- a/GameEngine.java
+++ b/GameEngine.java
@@ -460,10 +460,20 @@ public class GameEngine {
     
     // returns number of people who heard you
     private int sendToActiveUsers(String message) {
+        return sendToActiveUsers(message, null);
+    }
+    
+    // returns number of people who heard you, optionally excluding a specific chat ID
+    private int sendToActiveUsers(String message, Integer excludeChatId) {
         // If changed - also change the other function with the same name.
         int numListeners = 0;
         List<Integer> passive = new LinkedList<>();
         for (int recepientChatId : activeChats) {
+            // Skip the excluded chat ID if specified
+            if (excludeChatId != null && recepientChatId == excludeChatId.intValue()) {
+                continue;
+            }
+            
             Client recepient = getClientWithStorage(recepientChatId);
             if (recepient != null && recepient.lastActivity > curTimeSeconds - CHAT_TIMEOUT) {
                 telegram.sendMessage(recepient.chatId, message);
@@ -835,9 +845,9 @@ public class GameEngine {
         int expGained = loser.expForKillingMe();
         winner.exp += expGained;
         
-        // Send victory announcement to all active users
+        // Send victory announcement to all active users except the winner
         try {
-            sendToActiveUsers(PhraseGenerator.getWonPhrase(winner, loser));
+            sendToActiveUsers(PhraseGenerator.getWonPhrase(winner, loser), winner.chatId);
         } catch (Exception e) {
             // Ignore phrase generation errors in test environment
         }


### PR DESCRIPTION
Exclude the battle winner from the general victory announcement to prevent duplicate messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-77f68223-20a5-43cc-bcba-c676ff705a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77f68223-20a5-43cc-bcba-c676ff705a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

