### PR TITLE
Improve battle balance and opponent scaling

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -80,7 +80,17 @@ class Client {
     }
     BotConfig bc = pickBotType();
     this.username = bc.name;
-    for (int i = 1; i < this.level; i++) {
+    // Allocate level-up points prioritizing vitality to avoid one-shot kills (except level 1 bots)
+    int pointsToAllocate = Math.max(this.level - 1, 0);
+    if (opponent.level != 1) {
+      int opponentMaxHit = opponent.getMaxDamage() * 2; // consider potential crit
+      while (pointsToAllocate > 0 && getMaxHp() <= opponentMaxHit) {
+        vitality++;
+        pointsToAllocate--;
+      }
+    }
+    // Allocate any remaining points using species weights
+    for (int i = 0; i < pointsToAllocate; i++) {
       int ch = Utils.rndInRangeWeighted(bc.characteristics);
       if (ch == 0) {
         strength++;


### PR DESCRIPTION
Prioritize bot vitality allocation to prevent one-shot kills.

Bots (except level 1) now allocate skill points to vitality first until their HP exceeds the player's maximum potential damage (including crit), then distribute remaining points based on their archetype's characteristic weights. This addresses the issue of unbalanced opponents with high luck but low HP.

---
<a href="https://cursor.com/background-agent?bcId=bc-d70b9c5a-f7f5-41a3-8e34-3cee981334f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d70b9c5a-f7f5-41a3-8e34-3cee981334f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

