### PR TITLE
Enhance luck system for critical hit scaling

### DIFF
--- a/GameEngine.java
+++ b/GameEngine.java
@@ -1067,9 +1067,35 @@ public class GameEngine {
         if (isSuccess) {
             result = Utils.rndInRange((maxDamage + 1) / 2, maxDamage);
         }
-        if (Utils.rndInRange(1, 100) < client.getEffectiveLuck() * client.getEffectiveLuck()) {
-            result *= 2;
+        
+        // New critical hit system: luck affects both chance and damage multiplier
+        int luck = client.getEffectiveLuck();
+        int critChance;
+        
+        if (luck <= 10) {
+            // Original system: luck² percent chance up to 100% at luck 10
+            critChance = luck * luck;
+        } else {
+            // Beyond luck 10: guaranteed crit, but higher chance of bigger multipliers
+            critChance = 100;
         }
+        
+        if (Utils.rndInRange(1, 100) <= critChance) {
+            // Calculate critical damage multiplier based on luck
+            double multiplier;
+            if (luck <= 10) {
+                // Luck 1-10: standard 2x multiplier
+                multiplier = 2.0;
+            } else {
+                // Luck beyond 10: graduated damage scaling
+                // Base multiplier starts at 2.0 and grows by 0.1 per luck point beyond 10
+                // Luck 11 = 2.1x, Luck 15 = 2.5x, Luck 20 = 3.0x, etc.
+                multiplier = 2.0 + (luck - 10) * 0.1;
+            }
+            
+            result = (int) Math.round(result * multiplier);
+        }
+        
         return result;
     }
 


### PR DESCRIPTION
Update critical hit algorithm to make the 'luck' stat useful beyond 10 by introducing a scaling damage multiplier.

---
<a href="https://cursor.com/background-agent?bcId=bc-68a19019-6527-4b73-8296-6aa8f3d38c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68a19019-6527-4b73-8296-6aa8f3d38c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

