### PR TITLE
Improve trade description prompt accuracy

### DIFF
--- a/GameEngine.java
+++ b/GameEngine.java
@@ -34,8 +34,9 @@ public class GameEngine {
       "Nach genauer Untersuchung hast du die Krallen herausgezogen und in deinen Rucksack gesteckt.\" " + 
       "Gib am Ende keine Zusammenfassung, der Spieler sollte den Text sorgfältig lesen, um zu verstehen, was er gefunden hat. Stelle keine Fragen. " +
       "Gehe davon aus, dass der Held diesen Gegenstand am Ende in seinen Rucksack steckt.";
-    private static final String TRADER_PROMPT = "Der Held trifft auf einen Händler, der einen Tausch anbietet: " +
-      "1 %s gegen 1 %s. Du musst kurz beschreiben, wie der Händler aussieht und was er sagt. Der Held kann auch zu einem Markt oder " +
+    private static final String TRADER_PROMPT = "Der Held trifft auf einen Händler, der einen Tausch anbietet. " +
+      "WICHTIG: Der Händler GIBT dem Spieler 1 %s und der Spieler GIBT dem Händler 1 %s. " +
+      "Du musst kurz beschreiben, wie der Händler aussieht und was er sagt. Der Held kann auch zu einem Markt oder " +
       "in einen Laden kommen. Zum Beispiel: \"Ein alter Mann mit einer Kapuze tritt aus den Schatten. Seine Augen glitzern im Mondlicht, als er dich mustert. " +
       "'Ich habe etwas, was du gebrauchen könntest', flüstert er mit rauer Stimme. 'Gib mir deine Klaue und ich gebe dir dafür Gold. " +
       "Was sagst du?'\" Beschreibe die Kreatur oder Person kurz, halte dich an das Angebot und stelle am Ende die Frage nach der Entscheidung. " +


### PR DESCRIPTION
Clarify the `TRADER_PROMPT` to explicitly state the trade direction, preventing Gemini from reversing trade descriptions.

The previous prompt used "1 %s gegen 1 %s" (1 X against 1 Y), which was ambiguous and led Gemini to sometimes describe the player giving the requested item and the trader giving the offered item, instead of the correct direction. The updated prompt now explicitly states "Der Händler GIBT dem Spieler 1 %s und der Spieler GIBT dem Händler 1 %s."

---
<a href="https://cursor.com/background-agent?bcId=bc-0ea584b3-3bdf-4681-a77a-ca93fd723d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ea584b3-3bdf-4681-a77a-ca93fd723d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

